### PR TITLE
Add support for huge amount of images

### DIFF
--- a/Example/src/ImageGalleryScreen.tsx
+++ b/Example/src/ImageGalleryScreen.tsx
@@ -25,7 +25,7 @@ function getRandomIntInclusive(min: number, max: number) {
 
 const heights = [300, 400, 500, 540, 580, 600];
 
-const images = Array.from({ length: 5 }, (_, index) => {
+const images = Array.from({ length: 300 }, (_, index) => {
   const height =
     heights[getRandomIntInclusive(0, heights.length - 1)];
 


### PR DESCRIPTION
Now pager renders only a view with a width of `totalCount * dimensions.width + totalCount * gutterWidth`. All the pages have style of "position: 'absolute'` and `left: -getPageTranslate(currentPageIndex)`.

This allows us to have only few active rendered pages and be able to have easily few thousands of images in FlatList.