### PR TITLE
Remove react-cli global dependency need

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,14 @@ cd ios && pod install && cd ..
 Now, you can start the app:
 
 ```
-react-native run-ios
+npm run ios
 ```
 
 ### Running on Android
 
-Run the react native's cli command:
-
 ```
-react-native run-android
+npm run android
 ```
-
-**Important:** You will need to have an Android or iOS device or emulator connected as well as react-native-cli package installed globally.
-
 
 ## LICENSE
 


### PR DESCRIPTION
There are scripts already in the Example/package.json that will run the react-native from the project dependencies so there's no need have the package globally installed.
Plus we make sure user always runs cli matching version.

This also boots by itself the devices on their corresponding targeting platforms when running.
